### PR TITLE
Add explicit language about online interactions

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -15,7 +15,7 @@ If you are being harassed, notice that someone else is being harassed, or have a
 
 MLH representatives will be happy to help participants contact campus security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event. We value your attendance.
 
-We expect participants to follow these rules at all hackathon venues, hackathon-related social events, and on hackathon supplied transportation.
+We expect participants to follow these rules at all hackathon venues, online interactions in relation to the event, hackathon-related social events, and on hackathon supplied transportation.
 
 ## Reporting Procedures
 


### PR DESCRIPTION
We use the Code of Conduct to protect against online harassment in relation to events. We should explicitly mention in the Code of Conduct that it applies to attendee's behaviour online as well as in person.

We're interested to hear other ideas to help protect against online harassment at events! :)
