### PR TITLE
Add Contest T&Cs to Data Sharing Notice

### DIFF
--- a/data-sharing.md
+++ b/data-sharing.md
@@ -1,5 +1,5 @@
 # Data Sharing Notice
 
-*The following message should be placed at the end of your registration.*
+*This notice should be placed next to a checkbox in your event registration*
 
-We participate in Major League Hacking (MLH) as a MLH Member Event. You authorize us to share certain application/registration information for event administration, ranking, MLH administration, pre and post-event informational e-mails, and occasional messages about hackathons in line with the [MLH Privacy Policy](https://mlh.io/privacy). You agree to the [Contest Terms and Conditions](https://github.com/MLH/mlh-policies/tree/master/prize-terms-and-conditions).
+ I agree to the terms of both the [MLH Contest Terms and Conditions](https://github.com/MLH/mlh-policies/tree/master/prize-terms-and-conditions) and the [MLH Privacy Policy](https://mlh.io/privacy). Please note that you may receive pre and post-event informational e-mails and occasional messages about hackathons from MLH as per the MLH Privacy Policy.

--- a/data-sharing.md
+++ b/data-sharing.md
@@ -2,4 +2,4 @@
 
 *The following message should be placed at the end of your registration.*
 
-We participate in Major League Hacking (MLH) as a MLH Member Event. You authorize us to share certain application/registration information for event administration, ranking, MLH administration, pre and post-event informational e-mails, and occasional messages about hackathons in line with the [MLH Privacy Policy](https://mlh.io/privacy).
+We participate in Major League Hacking (MLH) as a MLH Member Event. You authorize us to share certain application/registration information for event administration, ranking, MLH administration, pre and post-event informational e-mails, and occasional messages about hackathons in line with the [MLH Privacy Policy](https://mlh.io/privacy). You agree to the [Contest Terms and Conditions](https://github.com/MLH/mlh-policies/tree/master/prize-terms-and-conditions).


### PR DESCRIPTION
I've just linked to the GitHub folder so it's easy to update if we need to. @jonmarkgo can I have a lgtm from you before we merge?