### PR TITLE
Added 7 high schools in the Waterloo Region

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -63,6 +63,7 @@ Blinn College
 Bloomsburg University of Pennsylvania
 Blue Mountain Academy
 BlueCrest University College
+Bluevale Collegiate Institute
 Boca Raton Community High School
 Boston College
 Boston Latin School
@@ -127,6 +128,7 @@ Case Western Reserve University School of Medicine
 Cedar Creek High School
 Cedar Ridge High School
 Cedarville University
+Centennial Collegiate Vocational Institute
 Centennial High School
 Cégep André-Laurendeau
 Cégep de Saint-Laurent
@@ -265,6 +267,7 @@ Florida State University
 Fontys Hogeschool
 Foothill College
 Fordham University
+Forest Heights Collegiate Institute
 Fort Scott Community College
 Fr. Conceicao Rodrigues College of Engineering
 Francis Holland School
@@ -339,6 +342,7 @@ Howard University
 Hudson County Community College
 Hudson Valley Community College
 Hunter College High School
+Huron Heights Secondary School
 H.N. Werkman College
 I.T.S Engineering College
 IT University of Copenhagen
@@ -750,6 +754,7 @@ Simon Fraser University
 Simpson College
 Simón Bolívar University
 Singapore University of Technology and Design
+Sir John A. Macdonald Secondary School
 Sir Padampat Singhania University
 Sitarambhai Naranji Patel Institute of Technology & Research Centre
 Skidmore College
@@ -774,6 +779,7 @@ St Mary's CE High School – Cheshunt
 St Mary's Catholic High School – Croydon
 St Paul's Catholic College – Sunbury-on-Thames
 St. Cloud State University
+St. David Catholic Secondary School
 "St. John's University, New York"
 "St. Mark's School, Hong Kong"
 St. Mary's Ryken High School
@@ -1124,6 +1130,7 @@ Wartburg College
 Washington State University
 Washington Township High School
 Washington University in St. Louis
+Waterloo Collegiate Institute
 Wayne State University
 Webb Bridge Middle School
 Wellesley College


### PR DESCRIPTION
All of these high schools were represented at JAMHacks 2017 (non-MLH event), some were also represented at Hack the North.