### PR TITLE
Add Westdale Secondary School

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -1136,6 +1136,7 @@ West Chester University
 West Morris Mendham High School
 West Potomac High School
 West Windsor-Plainsboro High School South
+Westdale Secondary School
 Western Governors University
 Western Kentucky University
 Western Michigan University


### PR DESCRIPTION
Add Westdale Secondary School, which will be hosting it's first Hackathon on February 3-4, 2018