### PR TITLE
Add Philadelphia area schools

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -19,6 +19,7 @@ Advanced Math and Science Academy Charter School
 Alameda High School
 Albany Medical College
 Albany State University (GA)
+Albright College
 Alfa College
 Allen High School
 Ambala College of Engineering and Applied Research
@@ -33,6 +34,7 @@ Anchor Bay High School
 Andover Central High School
 Anna University
 "Arcadia High School, California"
+Arcadia University
 Arizona State University
 Aston University
 Atlanta Metropolitan State College
@@ -91,8 +93,11 @@ Brooklyn Technical High School
 Brookwood High School
 Brown University
 Bucknell University
+Bucks County Community College
 Business Academy Aarhus
 COMSATS Institute of Information Technology
+Cabrini University
+Cairn University
 Caldwell University
 California High School
 California Institute of Technology
@@ -120,6 +125,7 @@ California Institute of Technology
 "California State University, Stanislaus"
 "California State University, Humboldt"
 "California State University, San Diego"
+California University of Pennsylvania
 Camden County College
 Cameron Heights Collegiate Institute
 Canyon Crest Academy
@@ -150,8 +156,10 @@ Channabasaveshwara Institute of Technology
 Chaparral Star Academy
 Chapel Hill High School
 Chattahoochee Technical College
+Cheyney University
 Cherokee High School
 Cherry Hill High School East
+Cherry Hill High School West
 Chinguacousy Secondary School
 Cincinnati State Technical and Community College
 Citrus College
@@ -192,6 +200,7 @@ Columbus State Community College
 Comenius University
 Community College of Allegheny County
 Community College of Baltimore County
+Community College of Philadelphia
 Community College of Rhode Island
 Concord Academy
 Concordia University
@@ -209,6 +218,7 @@ Coventry University
 Cranbrook Schools
 Cranfield University
 Creekview High School
+Cumberland County College
 Cupertino High School
 Dartmouth College
 Dawson College
@@ -217,7 +227,16 @@ DePauw University
 DeSales University
 Deerfield High School
 Del Norte High School
+Delaware County Community College - Main Campus (Marple)
+Delaware County Community College - Sharon Hill
+Delaware County Community College - Upper Darby
+Delaware County Community College - Downingtown
+Delaware County Community College - Exton
+Delaware County Community College - Phoenixville
+Delaware County Community College - West Grove
 Delaware State University
+Delaware Technical Community College
+Delaware Valley University
 Delhi Technological University
 Denison University
 Des Moines Area Community College
@@ -244,7 +263,11 @@ East Brunswick High School
 East Central University
 East Chapel Hill High Schoo
 East Los Angeles College
+EASTERN Center for Arts and Technology
+Eastern High School - Louisville
 Eastern Michigan University
+Eastern Regional High School
+Eastern University - St. Davids
 Eckerd College
 Edina High School
 Edinburgh Napier University
@@ -326,6 +349,7 @@ Guru Gobind Singh Indraprastha University
 Hampshire College
 Hampton University
 Hanze University of Applied Sciences
+Harcum College
 Harper College
 Harvard Medical School
 Harvard University
@@ -364,6 +388,7 @@ IT University of Copenhagen
 Iliria College
 Illinois Institute of Technology
 Illinois State University
+Immaculata University
 Imperial College London
 Indian Hills Community College
 Indian Institute of Engineering Science and Technology Shibpur
@@ -515,6 +540,7 @@ Manchester Metropolitan University
 Manhattan College
 Manhattan High School
 Manipal Institute of Technology
+Manor College
 Marc Garneau Collegiate Institute
 Marcellus High School
 Marianopolis College
@@ -575,7 +601,8 @@ Montana State University
 Montclair State University
 Montgomery Blair High School
 Montgomery College
-Montgomery County Community College
+Montgomery County Community College - Central Campus (Blue Bell)
+Montgomery County Community College - West Campus (Pottstown)
 Montgomery High School
 Montville Township High School
 Moore Middle School
@@ -605,6 +632,7 @@ National Institute of Technology Calicut
 National Research University Higher School Of Economics
 Netaji Subhas Institute Of Technology
 Netaji Subhash Engineering College
+Neumann University
 New Albany High School
 New Jersey City University
 New Jersey Institute of Technology
@@ -729,11 +757,17 @@ Roger Williams University
 Roosevelt High School
 Rosa Parks Middle School
 Rose-Hulman Institute of Technology
-Rowan College at Gloucester County
+Rosemont College
+Rowan College at Gloucester County - Mount Laurel
+Rowan College at Burlington County - Mount Holly
+Rowan College at Burlington County - Willingboro
+Rowan College at Burlington County - Pemberton
 Rowan University
 Roxbury High School
 Rudbecksgymnasiet
 "Rutgers, The State University of New Jersey"
+Rutgers University – Camden
+Rutgers University - Newark
 Ryde School
 Ryerson University
 SOAS University of London
@@ -743,6 +777,7 @@ Saginaw Valley State University
 Savannah State University
 Sahrdaya College of Engineering and Technology
 Saint Joseph High School
+Saint Joseph's Preparatory School - Philadelphia
 Saint Joseph's College of Maine
 Saint Paul College
 Saint Peter's Preparatory School
@@ -807,6 +842,7 @@ Southern Oregon University
 South Hills School of Business & Technology
 Spotswood High School
 Spring Arbor University
+Springside Chestnut Hill Academy
 Sreenidhi Institute of Science & Technology
 Sri Sivasubramaniya Nadar College of Engineering
 St Brendan High School
@@ -814,6 +850,7 @@ St Edwards University
 St Mary's CE High School – Cheshunt
 St Mary's Catholic High School – Croydon
 St Paul's Catholic College – Sunbury-on-Thames
+St. Charles Borromeo Seminary
 St. Cloud State University
 St. David Catholic Secondary School
 "St. John's University, New York"
@@ -852,6 +889,11 @@ Tecnológico de Estudio Superiores de Ixtapaluca
 Tecnológico de Estudios Superiores de Ecatepec
 Tecnológico de Estudios Superiores de Jilotepec
 Temple University
+Temple University - Health Sciences Campus
+Temple University - Ambler
+Temple University - Harrisburg
+Temple University - Tokyo
+Temple University - Rome
 Tenafly High School
 Tennessee State University
 Texas A&M University
@@ -882,6 +924,7 @@ The Ohio State University
 The Open University
 The Pennsylvania State University
 The Pennsylvania State University – Abington Campus
+The Pennsylvania State University – Brandywine
 The Pennsylvania State University – Harrisburg
 The Pennsylvania State University – York Campus
 The Pennsylvania State University – Berks
@@ -1147,9 +1190,11 @@ Université du Québec à Montréal
 University of Roehampton
 University of Southern Indiana
 University of Trento
+University of Valley Forge
 Universität Zürich
 Upper Canada College
 Upper Iowa University
+Upper Moreland High School
 Urbana High School
 Ursinus College
 Utah State University
@@ -1220,6 +1265,7 @@ Wilkes University
 William Lyon Mackenzie Collegiate Institute
 William Paterson University
 Williams College
+Williamson Free School of Mechanical Trades
 Wilmington University
 Wiltshire College
 Winona State University
@@ -1243,7 +1289,7 @@ Zespół Szkół Nr.2 im. Jana Pawła II w Miechowie
 Zespół Szkół nr 1 im. Jana Pawła II w Przysusze
 "Zespół Szkół Łączności, Monte Cassino 31"
 Zespół szkół nr 1 im. Stanisława Staszica w Bochni
-Zespół Szkół im. Jana Pawła II w Niepołomicach
+Zespół Szkół im. Jana Pawła II w Niepołomicach
 École Centrale Paris
 École Polytechnique de Montréal
 École de technologie supérieure
@@ -1276,7 +1322,9 @@ De Anza College
 Yeshiva University
 Instituto Tecnólogico de La Laguna (ITL)
 Bryn Mawr College
+Bryn Athyn College
 Instituto Tecnológico y de Estudios Superiores de Occidente (ITESO)
+Salem Community College
 Salem State University
 Hood College
 Brno University of Technology
@@ -1303,3 +1351,121 @@ Norco College
 Universidad Interamericana de Puerto Rico
 Maine South High School
 American High School
+John Bartram High School
+Thomas A. Edison High School - Philadelphia
+Samuel Fels High School - Philadelphia
+Frankford High School - Philadelphia
+Benjamin Franklin High School - Philadelphia
+Horace Furness High School
+Simon Gratz High School
+Kensington High School Complex
+Martin Luther King High School
+Abraham Lincoln High School - Philadelphia
+Northeast High School - Philadelphia
+Olney High School
+Overbrook High School - Philadelphia
+Roxborough High School
+William L. Sayre High School
+South Philadelphia High School
+Strawberry Mansion High School
+George Washington High School - Philadelphia
+West Philadelphia High School
+Academy at Palumbo
+The Arts Academy at Benjamin Rush
+William W. Bodine High School
+CAPA - Philadelphia High School for Creative and Performing Arts
+Geroge Washington Carver High School - Philadelphia
+Central High School - Phialdelphia
+Northwood Academy/Arts School
+Franklin Learning Center - Phialdelphia
+Julia R. Masterman School
+Northwest Parkway High School
+Parkway Center City High School
+Parkway West High School
+Philadelphia High School for Girls
+Science Leadership Academy
+Walter Biddle Saul High School
+Constitution High School - Philadelphia
+Murrell Dobbins Technical High School
+Microsoft School of the Future High School
+Lankenau High School
+Jules E. Mastbaum Technical High School
+Motivation High School (formerly John Bartram High School)
+Paul Robeson High School (formerly John Bartram High School)
+The Workshop School - Philadelphia
+Charter High School for Architecture and Design - Philadelphia
+Freire Charter High School
+TECH Freire Charter High School
+Mastery Charter School at Lenfest Campus
+"Math, Civics and Sciences Charter School - Philadelphia"
+Philadelphia Electrical and Technology Charter School
+Philadelphia Performing Arts Charter School (String Theory High School) - Vine Street Campus
+Community Academy of Philadelphia Charter School
+First Philadelphia Preparatory Charter School
+Franklin Towne Charter High School
+Mariana Bracetti Academy Charter School
+Maritime Academy Charter School (MACHS)
+"Mathematics, Science, and Technology Community Charter School (MaST)"
+New Foundations Charter School - Philadelphia
+Philadelphia Academy Charter School
+Sankofa Freedom Academy Charter School
+Tacony Academy Charter School
+Eastern University Academy Charter School
+Esperanza Academy Charter School
+Imhotep Institute Charter High School
+Mastery Charter School at Pickett Campus
+Multi-Cultural Academy Charter School
+YouthBuild Philadelphia Charter School
+Boys Latin of Philadelphia Charter School
+Mastery Charter School - Hardy Williams Academy
+Mastery Charter School - Thomas Campus
+World Communications Charter School
+Boys Latin of Philadelphia Charter School
+KIPP DuBois Charter School
+Mastery Charter School at Shoemaker Campus
+21st Century Cyber Charter School
+Achievement House Charter School - Online
+ACT Academy Cyber Charter School
+Agora Cyber Charter School
+ASPIRA Bilingual Cyber Charter School
+Central PA Digital Learning Foundation Charter School
+Commonwealth Charter Academy Charter School
+Esperanza Cyber Charter School
+Insight PA Cyber Charter School
+Pennsylvania Cyber Charter School
+Pennsylvania Distance Learning Charter School - Online
+Pennsylvania Leadership Charter School - Online
+Pennsylvania Virtual Charter School
+Reach Cyber Charter School
+Susq-Cyber Charter School
+Art Institute of Philadelphia
+Chestnut Hill College
+The Curtis Institute of Music
+Devry University - Philadelphia Center City
+Gwynedd Mercy University
+Holy Family University
+La Salle University - Philadelphia
+Moore College of Art and Design
+Peirce College
+Pennsylvania Academy of the Fine Arts
+Walnut Hill College
+Saint Joseph's University - Philadelphia
+Strayer University - Philadelphia Center City
+Strayer University - Bensalem
+Thomas Jefferson University - Philadelphia Center City
+Thomas Jefferson University - East Falls (formerly Philadelphia University)
+University of the Arts - Philadelphia
+University of the Sciences in Philadelphia
+Delaware Valley Academy of Medical and Dental Assistants
+Harrison Career Institute
+Hussian School of Art
+Lincoln Technical Institute - Center City Philadelphia
+Lincoln Technical Institute - Northeast Philadelphia
+Orleans Technical Institute
+Pennsylvania Institute of Technology - Center City Philadelphia
+Pennsylvania Institute of Technology - Media
+Star Technical Institute
+Talmudical Yeshiva of Philadelphia
+Thompson Institute - Philadelphia
+Pittsburgh Technical College - Philadelphia
+El Centro de Estudiantes

--- a/schools.csv
+++ b/schools.csv
@@ -49,12 +49,14 @@ Ball State University
 Bard College
 "Baruch College, CUNY"
 Baton Rouge Community College
+Battlefield High School
 Bayside High School
 Bayview Secondary School
 Beihang University
 "Bellevue College, Washington"
 Benedictine College
 Benha University
+Benjamin Franklin High School - Baltimore
 Bentley University
 Bergen Catholic High School
 Bergen Community College
@@ -82,6 +84,7 @@ Bowdoin College
 Bowie State University
 Brampton Centennial Secondary School
 Brandeis University
+Brentsville High School
 Briar Cliff University
 Brigham Young University
 British Columbia Institute of Technology
@@ -95,6 +98,7 @@ Brown University
 Bucknell University
 Bucks County Community College
 Business Academy Aarhus
+"C. D. Hylton High School"
 COMSATS Institute of Information Technology
 Cabrini University
 Cairn University
@@ -163,6 +167,7 @@ Cherry Hill High School West
 Chinguacousy Secondary School
 Cincinnati State Technical and Community College
 Citrus College
+City Neighbors High School
 City University London
 Claremont McKenna College
 Clarion University of Pennsylvania
@@ -205,12 +210,14 @@ Community College of Rhode Island
 Concord Academy
 Concordia University
 Conestoga College
+Conestoga High School
 Connecticut College
 "Conroe ISD Academy of Science and Technology, Texas"
 Cooper Union
 Coral Glades High School
 Cornell College
 Cornell University
+Council Rock High School North
 Council Rock High School South
 County College of Morris
 Covenant University
@@ -242,6 +249,7 @@ Denison University
 Des Moines Area Community College
 Dharmsinh Desai University
 Diablo Valley College
+Digital Harbor High School
 Dougherty Valley High School
 Dr. B. R. Ambedkar National Institute of Technology Jalandhar
 Drake University
@@ -302,6 +310,9 @@ Fontys Hogeschool
 Foothill College
 Fordham University
 Forest Heights Collegiate Institute
+Forest Park High School - Baltimore
+"Forest Park High School - Forest Park, GA"
+Forest Park High School - Woodbridge
 Fort Scott Community College
 Fr. Conceicao Rodrigues College of Engineering
 Francis Holland School
@@ -309,13 +320,15 @@ Francis Lewis High School
 Franklin High School
 Franklin W. Olin College of Engineering
 Frederick Community College
-Freedom High School
+Freedom High School - Bethlehem
+Freedom High School - Woodbridge
 Freehold High School
 Full Sail University
 Fullerton College
 GIDC Degree Engineering College
 Ganga International School
 Ganpat University
+Gar-Field Senior High School
 Garnet Valley High School
 George C. Marshall High School
 George Heriot's School
@@ -512,6 +525,7 @@ Linn-Mar High School
 Lisgar Collegiate Institute
 Little Flowers Public Sr Secondary School
 Livingston High School
+Loch Raven High School
 Lodz University of Technology
 London Metropolitan University
 London School of Economics and Political Science
@@ -657,6 +671,7 @@ North Carolina Agricultural and Technical (A&T) State University
 North Dakota State University
 North Hunterdon High School
 North Park Secondary School
+North Penn High School
 North Shore Community College
 Northeastern University
 Northern Arizona University
@@ -683,6 +698,7 @@ Oklahoma State University
 Onondaga Community College
 Opolska University of Technology
 Oregon State University
+Osbourn Park High School
 Otterbein University
 Oxford Academy High School
 Pace University
@@ -696,6 +712,8 @@ Parsons School of Design
 Parul Institute of Engineering & Technology
 Pasadena City College
 "Pascal English School, Cyprus"
+Patriot High School - Nokesville
+Patriot High School - Riverside
 Penncrest High School
 PES University
 Piedmont High School
@@ -716,6 +734,7 @@ Pope John Paul II High School
 Port Credit Secondary School
 Porter-Gaud School
 Portland State University
+Potomac Senior High School
 Poznań University of Technology
 "Presidency School, Surat."
 Preston High School
@@ -799,6 +818,7 @@ Sarvajanik College of Engineering & Technology
 Saurashtra University Rajkot
 Savitribai Phule Pune University
 "School of Visual Arts, New York"
+Scranton High School
 Seneca College
 Seton Hall University
 Seven Lakes High School
@@ -827,6 +847,7 @@ Sitarambhai Naranji Patel Institute of Technology & Research Centre
 Skidmore College
 Slippery Rock University of Pennsylvania
 Smith College
+Souderton Area High School
 South Brunswick High School
 South Carolina State University
 South Dakota School of Mines and Technology
@@ -860,7 +881,7 @@ St. Michael College of Engineering & Technology
 St. Raymond High School for Boys And Girls
 St. Theresa of Lisieux Catholic High School
 "St. Xavier's Senior Secondary School, Jaipur"
-St.Mary's Convent School
+St. Mary's Convent School
 Stanford University
 Staten Island Technical High School
 Stephen F. Austin State University
@@ -870,7 +891,8 @@ Stevenson University
 Stockton University
 Stockholm University
 Stonehill College
-Stonewall Jackson High School
+Stonewall Jackson High School - Manassas
+Stonewall Jackson High School - Quicksburg
 "Stony Brook University, SUNY"
 Stuyvesant High School
 Sulphur High School
@@ -914,6 +936,7 @@ The College Of William & Mary
 The College of New Jersey
 The College of Saint Rose
 The George Washington University
+"The Governor's School @ Innovation Park"
 The Harker School
 The Hill School
 The Katholieke Universiteit Leuven
@@ -1114,6 +1137,7 @@ Thomas Jefferson High School for Science and Technology
 Thomas Nelson Community College
 Thomas S. Wootton High School
 Tongji University
+Towson High School
 Towson University
 Trent University
 Trinity College
@@ -1193,6 +1217,7 @@ University of Trento
 University of Valley Forge
 Universität Zürich
 Upper Canada College
+Upper Darby High School
 Upper Iowa University
 Upper Moreland High School
 Urbana High School
@@ -1222,6 +1247,7 @@ Vincennes University
 Vincent Massey Secondary School
 Virginia Commonwealth University
 Virginia Tech
+"Virtual High School @ PWCS"
 Visvesvaraya National Institute of Technology
 Visvesvaraya Technological University
 Vivekanand Education Society's Institute of Technology
@@ -1245,6 +1271,7 @@ Wesleyan University
 West Chester University
 West Morris Mendham High School
 West Potomac High School
+West Scranton High School
 West Windsor-Plainsboro High School South
 Westdale Secondary School
 Western Governors University
@@ -1271,7 +1298,12 @@ Wiltshire College
 Winona State University
 Winston Churchill High School
 Winthrop University
-Woodbridge High School
+"Woodbridge High School - Bridgeville"
+"Woodbridge High School - Irvine"
+"Woodbridge High School - London"
+"Woodbridge High School - Woodbridge, NJ"
+"Woodbridge High School - Woodbridge, ON"
+"Woodbridge High School - Woodbridge, VA"
 Worcester Polytechnic Institute
 Worcester State University
 Wright State University


### PR DESCRIPTION
Sources:
- Wikipedia (independently verified for recently closed or merged schools - most notably ITT Tech, Del Val charter, Bartram HS split, 2010 Phila SD closures, Rowan College merger, Philadelphia University's merger as a Jefferson University campus)
- PA Charter Directory (Cyber Schools serving 9-12) - http://www.education.pa.gov/K-12/Charter%20Schools/Pages/default.aspx#tab-1
- Phila SD Charter Directory (Brick-and-Mortar Schools serving 9-12)  http://webgui.phila.k12.pa.us/offices/c/charter_schools/charter-school-directory

Philadelphia SD schools need to be update frequently, ~5 high/charter schools open or close every year.