### PR TITLE
APAC exceptions for membership guidelines

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -25,6 +25,7 @@ By sending information to the general reporting line, your report will go to any
 
 - North America General Reporting - +1 (409) 202-6060, incidents@mlh.io
 - Europe General Reporting - +44 80 0808 5675, incidents@mlh.io
+- Asia-Pacific General Reporting - incidents@mlh.io
 
 ## Special Incidents
 If you are uncomfortable reporting your situation to one or more of these people or need to contact any of them directly in case of emergency, direct contact details are listed below.  Incidents emailed to incidents@mlh.io may be addressed after the event.  

--- a/member-event-guidelines.md
+++ b/member-event-guidelines.md
@@ -162,6 +162,8 @@ benefits.
     products. Events may also receive assorted swag from MLH Season
     sponsors such as pens and t-shirts.
 
+    - **Asia-Pacific:** Select swag may not be available to Member Events in Asia-Pacific.
+
 8.  **Judging Coordination.** We know that judging is one of the most
     stressful periods during a hackathon. Our MLH representative on-site
     can assist you with running demos and judging during your event in a

--- a/member-event-guidelines.md
+++ b/member-event-guidelines.md
@@ -93,7 +93,7 @@ benefits.
     subject to approval from GitHub. Information will be sent out 40 days
     prior to your hackathon.
 
-    - **Asia-Pacific:** First Time Member Event grants are currently not available to Member Events in Asia-Pacific.
+    - **Asia-Pacific:** A grant First Time Member Events is currently not available to Member Events in Asia-Pacific.
 
 5.  **MLH Localhost Workshops.** Hackers want workshops. We’ve created a
     program called MLH Localhost to help you run high-quality workshops

--- a/member-event-guidelines.md
+++ b/member-event-guidelines.md
@@ -38,6 +38,7 @@ in addition to upholding the [Community Values](https://mlh.io/community-values)
     -   **North America:** United States, Canada, and Mexico.
     -   **Europe:** The United Kingdom, the European Union, and select other
         European countries.
+    -   **Asia-Pacific:** India, Sri Lanka, and select countries in Southeast Asia, East Asia, and Australasia.
 
 7.  **Attendance.** We require Member Events to have a minimum number of
     attendees. To qualify to be a Member Event, you must be planning
@@ -122,6 +123,8 @@ benefits.
     to keep track of which attendees have which devices. We are able to add
     non-MLH Hardware into our checkout system as requested. Lab contents
     vary by event.
+
+    - **Asia-Pacific:** The hardware lab is currently not available to Member Events in Asia-Pacific.
 
 4.  **MLH Emergency Budget.** On average, hackathons see about a 50% attrition
     rate between their signups during registration and the actual day-of
@@ -335,6 +338,8 @@ organizers must meet the following requirements:
     providing volunteers, our MLH rep will be freed up to help your
     organizing team and hackers with higher priority event support.
 
+    - **Asia-Pacific:** Reservation of a table for the MLH Hardware Lab is not required.
+
 5.  **Signage.** Display MLH Season and directional signage in key areas
     during the event. Much like displaying the Trust Badge on your
     website, having MLH signage on-site during the event signals your
@@ -372,4 +377,4 @@ questions regarding these policies, please contact us by email at
 [league@mlh.io](mailto:league@mlh.io).
 
 This guide was last updated on:
-May 1, 2019
+September 23, 2019

--- a/member-event-guidelines.md
+++ b/member-event-guidelines.md
@@ -93,6 +93,8 @@ benefits.
     subject to approval from GitHub. Information will be sent out 40 days
     prior to your hackathon.
 
+    - **Asia-Pacific:** First Time Member Event grants are currently not available to Member Events in Asia-Pacific.
+
 5.  **MLH Localhost Workshops.** Hackers want workshops. We’ve created a
     program called MLH Localhost to help you run high-quality workshops
     that get hackers excited either before the hackathon or teach your


### PR DESCRIPTION
- Added exceptions regarding Hardware lab

**Questions to resolve before merge**:

- There are some links within the guidelines to Google Drive docs. If we intend to support mainland China, we should provide alternatives.
- Several docs have named contacts, such as code of conduct, cheating incident response, etc - are these parties prepared to accept reports from APAC before the India team is in place? 
- For generic reporting, an APAC number would be good - Twilio forwarding? 