### PR TITLE
Add MNIT Jaipur in schools.csv

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -673,6 +673,7 @@ Maharaja Agrasen Institute of Technology
 Maharaja Surajmal Institute of Technology
 Maine South High School
 Malvern Preparatory School
+Malaviya National Institute of Technology
 Manalapan High School
 Manchester Metropolitan University
 Manhattan College


### PR DESCRIPTION
Please Add Malaviya National Institute of Technology, It's the full name of MNIT ,Jaipur, a prestigious college in India.