### PR TITLE
schools.csv: Correct name of a school

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -497,7 +497,7 @@ Immaculata University
 Imperial College London
 Indian Hills Community College
 Indian Institute of Engineering Science and Technology Shibpur
-Indian Institute of Technology Allahabad
+Indian Institute of Information Technology Allahabad
 Indian Institute of Technology Bhubaneswar
 Indian Institute of Technology Bombay
 Indian Institute of Technology Gandhinagar


### PR DESCRIPTION
Indian Institute of Technology Allahabad -> Indian Institute of Information Technology Allahabad