### PR TITLE
Add Kathmandu BernHardt College

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -602,6 +602,7 @@ Kansas State University
 Kantipur Engineering College
 Karlsruhe Institute of Technology
 Karunya Institute of Technology and Sciences
+Kathmandu BernHardt College
 Kaunas University of Technology
 Kean University
 Keele University


### PR DESCRIPTION
The college also hosted the first MLH member hackathon in Nepal "BernHack".