### PR TITLE
Fixing schools with commas but no quotations

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -397,9 +397,9 @@ Freire Charter High School
 Fremont High School
 Full Sail University
 Fullerton College
-Gandhi Institute of Technology and Management, Bengaluru
-Gandhi Institute of Technology and Management, Hyderabad
-Gandhi Institute of Technology and Management, Visakhapatnam
+"Gandhi Institute of Technology and Management, Bengaluru"
+"Gandhi Institute of Technology and Management, Hyderabad"
+"Gandhi Institute of Technology and Management, Visakhapatnam"
 Ganga International School
 Ganpat University
 Gar-Field Senior High School


### PR DESCRIPTION
A few schools aren't correctly quoted, leading to them having two columns instead of one. If this was intentional, feel free to reject the PR, thanks!