### PR TITLE
Updated the link of "MLH Contest Terms and Conditions" in participant-notices-and-agreements.md file

### DIFF
--- a/participant-notices-and-agreements.md
+++ b/participant-notices-and-agreements.md
@@ -8,7 +8,7 @@ MLH Code of Conduct: "I have read and agree to the [MLH Code of Conduct](https:/
 
 *This notice should be a required acknowledgement on your event registration.*
 
-Event Logistics Information: “I authorize you to share my application/registration information with Major League Hacking for event administration, ranking, and MLH administration in-line with the MLH Privacy Policy. I further agree to the terms of both the [MLH Contest Terms and Conditions](https://github.com/MLH/mlh-policies/tree/master/prize-terms-and-conditions) and the [MLH Privacy Policy](https://mlh.io/privacy).”
+Event Logistics Information: “I authorize you to share my application/registration information with Major League Hacking for event administration, ranking, and MLH administration in-line with the MLH Privacy Policy. I further agree to the terms of both the [MLH Contest Terms and Conditions](https://github.com/MLH/mlh-policies/blob/main/contest-terms.md) and the [MLH Privacy Policy](https://mlh.io/privacy).”
 
 
 # MLH Newsletters and Communication


### PR DESCRIPTION
Previously the link was > https://github.com/MLH/mlh-policies/tree/main/prize-terms-and-conditions , which is nothing but a dead end >>

![image](https://user-images.githubusercontent.com/58129377/189688802-304515e6-a8f9-445c-a8e2-d9277cb01987.png)

Updated it to > https://github.com/MLH/mlh-policies/blob/main/contest-terms.md which leads to >>

![image](https://user-images.githubusercontent.com/58129377/189689034-a40c0f4e-89c6-4e16-9d5b-486ecd0db623.png)


I believe this is where it is supposed to be redirecting. Let me know if I am wrong, I will make the changes.
 