### PR TITLE
Rename schools

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -1529,7 +1529,7 @@ Simsbury High School
 Sinclair Community College
 Singapore University of Technology and Design
 Sinhgad Institute of Technology
-Sir John A. Macdonald Secondary School
+Laurel Heights Secondary School
 Sir M Visvesvaraya Institute of Technology (Sir MVIT)
 Sir Padampat Singhania University
 Sitarambhai Naranji Patel Institute of Technology & Research Centre


### PR DESCRIPTION
Last year, Sir John A. Macdonald Secondary School, in Waterloo, Ontario, was renamed to Laurel Heights Secondary School. Google it for verification