### PR TITLE
Update name for Ontario Tech University

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -1248,6 +1248,7 @@ Old Dominion University
 "Old Westbury, SUNY"
 Olney High School
 Onondaga Community College
+Ontario Tech University
 Opolska University of Technology
 Oratary Prep School At Summit
 Oregon State University
@@ -1812,7 +1813,6 @@ The University of Northampton
 The University of Notre Dame
 The University of Nottingham
 The University of Oklahoma
-The University of Ontario Institute of Technology
 The University of Oregon
 The University of Ottawa
 The University of Oulu


### PR DESCRIPTION
The University of Ontario Institute of Technology has been rebranded as Ontario Tech University in 2018, any current students would refer to it by the second name