### PR TITLE
Add more schools to schools.csv

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -1486,6 +1486,7 @@ Saint Paul College
 Saint Peter's Preparatory School
 Saint Peter's University
 SAL Engineering and Technical Institute
+Salisbury University
 Salem Community College
 Salem State University
 Sambalpur University Institute of Information Technology (SUIIT)

--- a/schools.csv
+++ b/schools.csv
@@ -1362,6 +1362,7 @@ Potomac Senior High School
 Poznań University of Technology
 Pranveer Singh Institute of Technology
 Prathyusha Engineering College
+Pratt Institute
 "Presidency School, Surat."
 Preston High School
 Preston University

--- a/schools.csv
+++ b/schools.csv
@@ -2175,6 +2175,7 @@ Westfield High School
 Westminster College
 Westminster School
 Westwood High School
+Wheaton High School
 Whitefish Bay High School
 Whitworth University
 Wichita State University


### PR DESCRIPTION
Here are some missing schools that [Bitcamp](https://bit.camp/) has encountered during registration:
- [Pratt Institute](https://www.pratt.edu/)
- [Salisbury University](https://www.salisbury.edu/)
- [Wheaton High School](https://www2.montgomeryschoolsmd.org/schools/wheatonhs/)