### PR TITLE
SJAM -> LHSS

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -957,6 +957,7 @@ Lakshmi Narayan College of Technology (LNCT)
 Lampeter-Strasburg High School
 Lancaster University
 Lankenau High School
+Laurel Heights Secondary School
 Laval University
 Lawrence Technological University
 Lawrence University
@@ -1564,7 +1565,6 @@ Simsbury High School
 Sinclair Community College
 Singapore University of Technology and Design
 Sinhgad Institute of Technology
-Sir John A. Macdonald Secondary School
 Sir M Visvesvaraya Institute of Technology (Sir MVIT)
 Sir Padampat Singhania University
 Sitarambhai Naranji Patel Institute of Technology & Research Centre


### PR DESCRIPTION
Our school changed its name in 2022. Proof: https://en.wikipedia.org/wiki/Laurel_Heights_Secondary_School