### PR TITLE
update TMU name

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -1469,7 +1469,7 @@ Rutgers University – Camden
 "Rutgers, The State University of New Jersey"
 Ryde School
 Rye High School
-Ryerson University
+Toronto Metropolitan University
 S A Engineering College
 S G Balekundri Institute of Technology
 Sachdeva Institute of Technology


### PR DESCRIPTION
Ryerson University officially changes its name to Toronto Metropolitan University.