### PR TITLE
Add Launchpad Philly

### DIFF
--- a/schools.csv
+++ b/schools.csv
@@ -2224,3 +2224,4 @@ Zespół Szkół im. Jana Pawła II w Niepołomicach
 Zespół Szkół nr 1 im. Jana Pawła II w Przysusze
 Zespół szkół nr 1 im. Stanisława Staszica w Bochni
 Zespół Szkół Nr.2 im. Jana Pawła II w Miechowie
+Launchpad Philly


### PR DESCRIPTION
Launchpad Philly is a tech-focused education program based in Philadelphia that offers immersive training in software development. Its primary aim is to provide high school juniors and graduating seniors with the skills necessary to become professional software developers through hands-on learning, mentorship, and industry-aligned curricula.