### PR TITLE
Update European Reporting Numbers in Code of Conduct

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -26,7 +26,8 @@ By sending information to the general reporting line, your report will go to our
 
 - North America General Reporting - +1 409 202 6060, incidents@mlh.io
 - Canada General Reporting - +1 343 453 4532, incidents@mlh.io
-- Europe General Reporting - +44 800 808 5675, incidents@mlh.io
+- UK General Reporting - +44 800 808 5675, incidents@mlh.io
+- Europe General Reporting - +44 333 038 5995, incidents@mlh.io
 - Asia-Pacific General Reporting - +91 000 80004 02492, incidents@mlh.io
 - India General Reporting - 000 80004 02492, incidents@mlh.io
 

--- a/incident-response.md
+++ b/incident-response.md
@@ -9,7 +9,8 @@ If you cannot contact your on-site MLHer, immediately contact MLH’s Incident R
 
 - North America General Reporting - +1 409 202 6060, incidents@mlh.io
 - Canada General Reporting - +1 343 453 4532, incidents@mlh.io
-- Europe General Reporting - +44 800 808 5675, incidents@mlh.io
+- UK General Reporting - +44 800 808 5675, incidents@mlh.io
+- Europe General Reporting - +44 333 038 5995, incidents@mlh.io
 - Asia-Pacific General Reporting - +91 000 80004 02492, incidents@mlh.io
 - India General Reporting - 000 80004 02492, incidents@mlh.io
 


### PR DESCRIPTION
This pull request updates the contact information in the `code-of-conduct.md` file to clarify and expand the general reporting lines for Europe and the UK.

Contact information updates:

* Changed the "Europe General Reporting" phone number and added a separate "UK General Reporting" line with the previous number to distinguish between the two regions.
* Added a new phone number for "Europe General Reporting" to provide more accurate regional support.