### PR TITLE
Update Europe & UK General Reporting Numbers

### DIFF
--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -26,7 +26,8 @@ By sending information to the general reporting line, your report will go to our
 
 - North America General Reporting - +1 409 202 6060, incidents@mlh.io
 - Canada General Reporting - +1 343 453 4532, incidents@mlh.io
-- Europe General Reporting - +44 800 808 5675, incidents@mlh.io
+- UK General Reporting - +44 800 808 5675, incidents@mlh.io
+- Europe General Reporting - +44 333 038 5995, incidents@mlh.io
 - Asia-Pacific General Reporting - +91 000 80004 02492, incidents@mlh.io
 - India General Reporting - 000 80004 02492, incidents@mlh.io
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -41,4 +41,4 @@ If you are uncomfortable reporting your situation to one or more of these people
 MLH reserves the right to revise, make exceptions to, or otherwise amend these policies in whole or in part. If you have any questions regarding these policies, please contact MLH by e-mail at incidents@mlh.io.
 
 This document was last updated on: 
-February 14th 2025
+April 16th 2026

--- a/incident-response.md
+++ b/incident-response.md
@@ -9,7 +9,8 @@ If you cannot contact your on-site MLHer, immediately contact MLH’s Incident R
 
 - North America General Reporting - +1 409 202 6060, incidents@mlh.io
 - Canada General Reporting - +1 343 453 4532, incidents@mlh.io
-- Europe General Reporting - +44 800 808 5675, incidents@mlh.io
+- UK General Reporting - +44 800 808 5675, incidents@mlh.io
+- Europe General Reporting - +44 333 038 5995, incidents@mlh.io
 - Asia-Pacific General Reporting - +91 000 80004 02492, incidents@mlh.io
 - India General Reporting - 000 80004 02492, incidents@mlh.io
 

--- a/incident-response.md
+++ b/incident-response.md
@@ -59,5 +59,5 @@ If attendees express distress or anger about an incident and its handling:
 - Reassure them that such matters are taken seriously and that appropriate steps are being taken or have been taken, respecting the privacy of those involved.
 - If they wish to provide further feedback or discuss their concerns in more detail, offer them clear channels to do so by speaking further with the on-site MLHer when appropriate, or encouraging them to provide written feedback directly to MLH via incidents@mlh.io so their concerns can be addressed.
 
-Last Revised: 2025-07-08
+Last Revised: 2026-04-16
 


### PR DESCRIPTION
This pull request updates contact information and revision dates in the code of conduct and incident response documentation, as well as the last-updated timestamp in the verified schools list. The most important changes are:

**Contact Information Updates:**

* Added a dedicated UK reporting line and updated the Europe reporting line in both `code-of-conduct.md` and `incident-response.md` to provide more accurate and region-specific contact options. [[1]](diffhunk://#diff-f1a69a41a835b5265e1c58e11395a894ac30fc6b0afe1ca834738955261d2ec5L29-R30) [[2]](diffhunk://#diff-86347c4b24067336123f5c62d8a11bd7c11defe720c434224403604366df72c4L12-R13)

**Documentation Updates:**

* Updated the "last updated" date in `code-of-conduct.md` to April 16th, 2026, reflecting the latest revision.
* Updated the "Last Revised" date in `incident-response.md` to 2026-04-16.